### PR TITLE
Fix/loop over view creation

### DIFF
--- a/app/src/main/java/com/example/android/spotifystreamer/fragments/adapters/ArtistSearchAdapter.java
+++ b/app/src/main/java/com/example/android/spotifystreamer/fragments/adapters/ArtistSearchAdapter.java
@@ -27,24 +27,37 @@ public class ArtistSearchAdapter extends ArrayAdapter<Artist> {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
-        LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        ViewHolder viewHolder;
 
-        View rowView = inflater.inflate(R.layout.artist_search_list_item, parent, false);
-
-        ImageView imageView = (ImageView) rowView.findViewById(R.id.artist_search_list_item_poster);
-        TextView textView = (TextView) rowView.findViewById(R.id.artist_search_list_item_name);
-
-        Artist artist = artists.get(position);
-
-        textView.setText(artist.name);
-
-        // No instruction here, so just keep the first image if any
-        if (artist.images.isEmpty()) {
-            imageView.setImageResource(R.drawable.no_image);
+        if (convertView == null) {
+            LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            convertView = inflater.inflate(R.layout.artist_search_list_item, parent, false);
+            viewHolder = new ViewHolder();
+            viewHolder.textView = (TextView) convertView.findViewById(R.id.artist_search_list_item_name);
+            viewHolder.imageView = (ImageView) convertView.findViewById(R.id.artist_search_list_item_poster);
+            convertView.setTag(viewHolder);
         } else {
-            Picasso.with(context).load(artist.images.get(0).url).into(imageView);
+            viewHolder = (ViewHolder) convertView.getTag();
         }
 
-        return rowView;
+        Artist artist = artists.get(position);
+        if (artist != null) {
+            viewHolder.textView.setText(artist.name);
+
+            // No instruction here, so just keep the first image if any
+            if (artist.images == null || artist.images.isEmpty() || artist.images.get(0) == null
+                    || artist.images.get(0).url == null || artist.images.get(0).url.isEmpty()) {
+                viewHolder.imageView.setImageResource(R.drawable.no_image);
+            } else {
+                Picasso.with(context).load(artist.images.get(0).url).into(viewHolder.imageView);
+            }
+        }
+
+        return convertView;
+    }
+
+    private class ViewHolder {
+        TextView textView;
+        ImageView imageView;
     }
 }

--- a/app/src/main/java/com/example/android/spotifystreamer/fragments/adapters/ArtistTrackAdapter.java
+++ b/app/src/main/java/com/example/android/spotifystreamer/fragments/adapters/ArtistTrackAdapter.java
@@ -26,25 +26,38 @@ public class ArtistTrackAdapter extends ArrayAdapter<ParcelableTrack> {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
-        LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        ViewHolder viewHolder;
 
-        View rowView = inflater.inflate(R.layout.artist_track_list_item, parent, false);
-
-        ImageView imageView = (ImageView) rowView.findViewById(R.id.artist_track_list_item_poster);
-        TextView titleTextView = (TextView) rowView.findViewById(R.id.artist_track_list_item_title);
-        TextView albumTextView = (TextView) rowView.findViewById(R.id.artist_track_list_item_album);
-
-        ParcelableTrack parcelableTrack = parcelableTracks.get(position);
-
-        titleTextView.setText(parcelableTrack.title);
-        albumTextView.setText(parcelableTrack.album);
-
-        if (parcelableTrack.poster == null) {
-            imageView.setImageResource(R.drawable.no_image);
+        if (convertView == null) {
+            LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            convertView = inflater.inflate(R.layout.artist_track_list_item, parent, false);
+            viewHolder = new ViewHolder();
+            viewHolder.titleTextView = (TextView) convertView.findViewById(R.id.artist_track_list_item_title);
+            viewHolder.albumTextView = (TextView) convertView.findViewById(R.id.artist_track_list_item_album);
+            viewHolder.imageView = (ImageView) convertView.findViewById(R.id.artist_track_list_item_poster);
+            convertView.setTag(viewHolder);
         } else {
-            Picasso.with(context).load(parcelableTrack.poster).into(imageView);
+            viewHolder = (ViewHolder) convertView.getTag();
         }
 
-        return rowView;
+        ParcelableTrack parcelableTrack = parcelableTracks.get(position);
+        if (parcelableTrack != null) {
+            viewHolder.titleTextView.setText(parcelableTrack.title);
+            viewHolder.albumTextView.setText(parcelableTrack.album);
+
+            if (parcelableTrack.poster == null || parcelableTrack.poster.isEmpty()) {
+                viewHolder.imageView.setImageResource(R.drawable.no_image);
+            } else {
+                Picasso.with(context).load(parcelableTrack.poster).into(viewHolder.imageView);
+            }
+        }
+
+        return convertView;
+    }
+
+    private class ViewHolder {
+        TextView titleTextView;
+        TextView albumTextView;
+        ImageView imageView;
     }
 }


### PR DESCRIPTION
In adapters, the first execution of getView now instanciates a ViewHolder class, retained in the convertView's tag.
View is reused on each iteration instead of being created.
