### PR TITLE
Feature/add subtitle in top tracks search bar

### DIFF
--- a/app/src/main/java/com/example/android/spotifystreamer/fragments/ArtistSearchActivityFragment.java
+++ b/app/src/main/java/com/example/android/spotifystreamer/fragments/ArtistSearchActivityFragment.java
@@ -66,10 +66,10 @@ public class ArtistSearchActivityFragment extends Fragment {
         searchListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                // Click on an artist, send an intent with its id to retrieve its tracks
+                // Click on an artist, send an intent holding it to retrieve its tracks
                 ParcelableArtist parcelableArtist = (ParcelableArtist) parent.getItemAtPosition(position);
                 if (parcelableArtist != null && parcelableArtist.id != null) {
-                    Intent intent = new Intent(getActivity(), ArtistTracksActivity.class).putExtra(Intent.EXTRA_TEXT, parcelableArtist.id);
+                    Intent intent = new Intent(getActivity(), ArtistTracksActivity.class).putExtra("parcelableArtist", parcelableArtist);
                     startActivity(intent);
                 }
             }

--- a/app/src/main/java/com/example/android/spotifystreamer/models/ParcelableArtist.java
+++ b/app/src/main/java/com/example/android/spotifystreamer/models/ParcelableArtist.java
@@ -13,10 +13,31 @@ public class ParcelableArtist implements Parcelable {
         return 0;
     }
 
+    public ParcelableArtist() {
+        super();
+    }
+
+    public ParcelableArtist(Parcel source) {
+        id = source.readString();
+        name = source.readString();
+        poster = source.readString();
+    }
+
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(id);
         dest.writeString(name);
         dest.writeString(poster);
     }
+
+    public static final Parcelable.Creator<ParcelableArtist> CREATOR
+            = new Parcelable.Creator<ParcelableArtist>() {
+        public ParcelableArtist createFromParcel(Parcel in) {
+            return new ParcelableArtist(in);
+        }
+
+        public ParcelableArtist[] newArray(int size) {
+            return new ParcelableArtist[size];
+        }
+    };
 }


### PR DESCRIPTION
ParcelableArtist sent in Intent to TopTracksActivity instead of just id.
Allows to retrieve it on fragment creation and display artist's name in ActionBar subtitle.
